### PR TITLE
change what type interpret() accepts

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,13 @@ pub enum Error {
     NoKeyGiven,
 }
 
+/// # Examples
+///
+/// configuration lines must contain a ':' and use a space as a delimiter
+/// ```
+/// let config = crate::rakh::interpret("deno_is_uncool:false\nname_of_funny_crab:Ferris".to_string()).unwrap();
+/// assert_eq!(config.get("deno_is_uncool").unwrap(), "false");
+/// ```
 pub fn interpret(code: String) -> Result<HashMap<String, String>, Error> {
     let lines = code.split('\n');
     let mut hashmap: HashMap<String, String> = HashMap::new();
@@ -23,4 +30,23 @@ pub fn interpret(code: String) -> Result<HashMap<String, String>, Error> {
     }
 
     Ok(hashmap)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::interpret;
+
+    #[test]
+    fn parsing_works() {
+        let config = interpret(
+            "rust_is_awesome:true\ndeno_is_uncool:false\nname_of_funny_crab:Ferris".to_string(),
+        )
+        .unwrap();
+        assert_eq!(config.get("rust_is_awesome"), Some(&"true".to_string()));
+        assert_eq!(config.get("deno_is_uncool"), Some(&"false".to_string()));
+        assert_eq!(
+            config.get("name_of_funny_crab"),
+            Some(&"Ferris".to_string())
+        );
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,12 +11,12 @@ pub enum Error {
 ///
 /// configuration lines must contain a ':' and use a space as a delimiter
 /// ```
-/// let config = crate::rakh::interpret("deno_is_uncool:false\nname_of_funny_crab:Ferris".to_string()).unwrap();
-/// assert_eq!(config.get("deno_is_uncool").unwrap(), "false");
+/// let config = crate::rakh::interpret("deno_is_uncool:false\nname_of_funny_crab:Ferris").unwrap();
+/// assert_eq!(config.get("name_of_funny_crab").unwrap().eq(&"Ferris"), true);
 /// ```
-pub fn interpret(code: String) -> Result<HashMap<String, String>, Error> {
+pub fn interpret(code: &str) -> Result<HashMap<&str, &str>, Error> {
     let lines = code.split('\n');
-    let mut hashmap: HashMap<String, String> = HashMap::new();
+    let mut hashmap: HashMap<&str, &str> = HashMap::new();
 
     for line in lines {
         let key_value = line.split_once(':');
@@ -25,7 +25,7 @@ pub fn interpret(code: String) -> Result<HashMap<String, String>, Error> {
             if key_value.0.is_empty() {
                 return Err(Error::NoKeyGiven);
             }
-            hashmap.insert(key_value.0.to_string(), key_value.1.to_string());
+            hashmap.insert(key_value.0, key_value.1);
         }
     }
 
@@ -38,15 +38,15 @@ mod tests {
 
     #[test]
     fn parsing_works() {
-        let config = interpret(
-            "rust_is_awesome:true\ndeno_is_uncool:false\nname_of_funny_crab:Ferris".to_string(),
-        )
-        .unwrap();
-        assert_eq!(config.get("rust_is_awesome"), Some(&"true".to_string()));
-        assert_eq!(config.get("deno_is_uncool"), Some(&"false".to_string()));
+        let config =
+            interpret("rust_is_awesome:true\ndeno_is_uncool:false\nname_of_funny_crab:Ferris")
+                .unwrap();
+
+        assert_eq!(config.get("rust_is_awesome").unwrap().eq(&"true"), true);
+        assert_eq!(config.get("deno_is_uncool").unwrap().eq(&"false"), true);
         assert_eq!(
-            config.get("name_of_funny_crab"),
-            Some(&"Ferris".to_string())
+            config.get("name_of_funny_crab").unwrap().eq(&"Ferris"),
+            true
         );
     }
 }


### PR DESCRIPTION
Changed the parameter 'code' to be a &str instead of a String; changed the test and doctests to fit this change